### PR TITLE
Add filetypes for syntax detection

### DIFF
--- a/Syntaxes/SASS.tmLanguage
+++ b/Syntaxes/SASS.tmLanguage
@@ -3,7 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
-	<array/>
+	<array>
+            <string>sass</string>
+            <string>scss</string>
+        </array>
 	<key>foldingStartMarker</key>
 	<string>/\*|^#|^\*|^\b|^\.</string>
 	<key>foldingStopMarker</key>


### PR DESCRIPTION
In the current build you have to pick your syntax every time. This picks up the syntax type for SCSS and SASS files.
