### PR TITLE
Enable css.sass and css.scss file types

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -6,6 +6,8 @@
 	<array>
             <string>sass</string>
             <string>scss</string>
+            <string>css.sass</string>
+            <string>css.scss</string>
         </array>
 	<key>foldingStartMarker</key>
 	<string>/\*|^#|^\*|^\b|^\.</string>


### PR DESCRIPTION
The Ruby on Rails framework uses by default .css.scss or .css.sass extensions. Would be nice to get the right syntax be default :)
