### PR TITLE
Expanding symbols returned in the @ Go To Symbol menu

### DIFF
--- a/Preferences/Symbol List: Selectors.tmPreferences
+++ b/Preferences/Symbol List: Selectors.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Symbol List: Selectors</string>
 	<key>scope</key>
-	<string>entity.other.attribute-name.class, entity.other.attribute-name.id</string>
+	<string>entity.other.attribute-name.class, entity.other.attribute-name.id, keyword.control.untitled</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>


### PR DESCRIPTION
Adding Go To Symbols from another fork to include h1, etc...

I experimented a bit with the CSS section's definitions but couldn't get it to work, and I found this one on another fork and it ignores id's and selectors but caught elements. What you had seemed to grab ids and everything fine but ignored elements, and this seems to marry the best of both together. I am sure there is a better way to do this.. if so hopefully someone will bring it up in the comments. :)
