### PR TITLE
Reverse sort of pseudo-classes to fix specificity issue

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -126,7 +126,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>:(active|after|before|checked|default|disabled|empty|enabled|first|first-child|first-letter|first-line|first-of-type|focus|hover|in-range|indeterminate|invalid|lang|last-child|last-of-type|left|link|not|nth-child|nth-last-child|nth-last-of-type|nth-of-type|only-child|only-of-type|optional|out-range|read-only|read-write|required|right|root|valid|visited)</string>
+			<string>:(visited|valid|root|right|required|read-write|read-only|out-range|optional|only-of-type|only-child|nth-of-type|nth-last-of-type|nth-last-child|nth-child|not|link|left|last-of-type|last-child|lang|invalid|indeterminate|in-range|hover|focus|first-of-type|first-line|first-letter|first-child|first|enabled|empty|disabled|default|checked|before|after|active)</string>
 			<key>name</key>
 			<string>entity.other.attribute-name.tag.pseudo-class</string>
 		</dict>


### PR DESCRIPTION
Sorry, forgot to fix a bug.
