### PR TITLE
Fixed Sass commands recognition

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -25,7 +25,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>@(import|mixin|include|charset|import|media|page|font-face|namespace) [\/\.\w-]*\b</string>
+			<string>@(import|mixin|include|charset|import|media|page|font-face|namespace|for)\b</string>
 			<key>name</key>
 			<string>keyword.control.at-rule.sass</string>
 		</dict>


### PR DESCRIPTION
Syntax didn't detect commands like: import, mixin etc because of a regex in the end of the line. I also added "for" command to the set.
