### PR TITLE
Match %placeholder instances like .class instances

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -48,7 +48,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\.[a-zA-Z0-9_-]+</string>
+			<string>[\.%][a-zA-Z0-9_-]+</string>
 			<key>name</key>
 			<string>entity.other.attribute-name.class.sass</string>
 		</dict>


### PR DESCRIPTION
Sass 3.2 introduced `%placeholders`. It's like doing `.class` except that the rules defined therein will not be directly produced. They'll only be produced when something extends the `%placeholder` with `@extend`. My patch treats `%placeholder` like `.class` in terms of highlighting. Without this patch, using a `%placeholder` will result in a huge block of non-highlighted text.

Example of the issue:

![Bad highlighting](https://f.cloud.github.com/assets/353790/65086/3a2c294c-5e69-11e2-86f2-61383bd8cd3d.png)

Example of `%placeholder` in use:

``` sass
%placeholder
  color: white
  background: black

.bar
  @extend %placeholder

.foo
  @extend %placeholder
  font-size: 2em
```

Produces:

``` css
.bar, .foo {
  color: white;
  background: black;
}

.foo {
  font-size: 2em;
}
```
