### PR TITLE
Add mixin shorthand statement.

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -30,6 +30,12 @@
 			<string>keyword.control.at-rule.sass</string>
 		</dict>
 		<dict>
+			<key>match</key>
+			<string>(?&lt;![!&lt;&gt;=a-zA-Z0-9_-]|[&lt;&gt;=a-zA-Z0-9_-] )[=+][a-zA-Z0-9_-]+</string>
+			<key>name</key>
+			<string>keyword.control.mixin-shorthand.sass</string>
+		</dict>
+		<dict>
 			<key>begin</key>
 			<string>"</string>
 			<key>end</key>


### PR DESCRIPTION
I _really_ wanted to be able to add highlighting to mixin shorthand declarations (i.e. `=mixin`, `+mixin`). This regex matches them, and also insures that math and equality operations are not matched. 
_Note: I'm not savvy in regards to naming conventions for syntax matching statements, so please change the name of this statement if need be._
