### PR TITLE
Syntax highlighting for 'function' and 'return' keywords

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -25,7 +25,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>@(extend|import|mixin|include|charset|import|media|page|font-face|namespace|for)\b</string>
+			<string>@(extend|import|mixin|include|charset|import|media|page|font-face|namespace|for|function|return)\b</string>
 			<key>name</key>
 			<string>keyword.control.at-rule.sass</string>
 		</dict>


### PR DESCRIPTION
Since Sass version 3.1.0 (http://thesassway.com/advanced/pure-sass-functions) there has been 'function' and 'return' keywords that has not been highlighted in the editor.
