### PR TITLE
Updates README.md to include alternative installation and improved solution for HAML/Ruby conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,24 @@ Once you have Package Control installed, activate your Command Palette and choos
 
 Then, search for **"Sass"** and press Enter. In mere moments you'll be up and running with full syntax highlighting, tab completion and more. Huzzah!
 
+### With Git (Windows)
+
+From within Sublime Text go to:
+```Preferences > Browse Packages...```
+
+Right-click and select:
+```Git Bash Here```
+
+From the Git Bash: 
+```git clone https://github.com/nathos/sass-textmate-bundle.git```
+
+Restart Sublime Text.
+    
 ### Putting HAML in its place
 
 You may find that when you open files with the `.sass` extension, Sublime Text 2 initially interprets the syntax as HAML. To permanently fix this, open `Packages/Rails/Ruby Haml.tmLanguage` and delete the line `<string>sass</string>`.
+
+Alternatively, you can open a sass file in Sublime Text (with either the .sass or .scss extension) and go to ```View > Syntax``` and select Sass. This will also ensure updated won't override this setting in future.
 
 ## About & Credit
 This was originally a fork of <https://github.com/seaofclouds/sass-textmate-bundle>, and includes the best contributions of people [throughout the network](https://github.com/nathos/sass-textmate-bundle/network).


### PR DESCRIPTION
Basically, I've just added a few lines to the README.md on a "Git-first" install method for anyone who doesn't have the Package Manager installed. Someone with Windows and Mac OS knowledge can make it mac friendly if they want.

Finally, the alternative method I've added is much simpler and also won't be overwritten by an update of Sublime Text.

Everything I've entered I've tested and it works...on Windows at least.