### PR TITLE
/* */ comments don't exist in Sass, ending is determined by indent

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -80,9 +80,9 @@
 			<key>begin</key>
 			<string>/\*</string>
 			<key>end</key>
-			<string>\*/</string>
+			<string>$\n?</string>
 			<key>name</key>
-			<string>comment.block.sass</string>
+			<string>comment.line.slash-asterisk.sass</string>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
From [Sass Indented Syntax](http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html):

> Comments beginning with `/*` are preserved in the CSS output, although
> unlike SCSS they don’t require a closing `*/`.

This fix is imperfect in that it breaks CSS-style block comment coloring (subsequent comment lines are not colored as comments), but at least now the rest of the page isn't inadvertently grayed out.

Before:
![screen shot 2014-02-18 at 7 34 01 pm](https://f.cloud.github.com/assets/1570168/2203187/e2a1b3ba-9916-11e3-89ce-def221389915.png)
After:
![screen shot 2014-02-18 at 7 34 26 pm](https://f.cloud.github.com/assets/1570168/2203188/e6546692-9916-11e3-8c19-07f266c7ebe6.png)

I am submitting a pull request to this branch of this repo because this appears to be the de-facto Sass package available on [Sublime Package Control](https://sublime.wbond.net/search/sass).
