### PR TITLE
Fix comment block highlight over SASS syntax

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -190,10 +190,8 @@
 			<string>variable.parameter.sass</string>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>/\*</string>
-			<key>end</key>
-			<string>\*/</string>
+			<key>match</key>
+			<string>((^\ \*)|(\/\*))(.*)$</string>
 			<key>name</key>
 			<string>comment.block.sass</string>
 		</dict>


### PR DESCRIPTION
Fix comment block highlight SASS syntax problem when many comment lines (doesn't affect SCSS syntax)
