### PR TITLE
Add highlighting of user-defined functions

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -291,6 +291,58 @@
 			</array>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>([\w-]+)\s*(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>meta.function-call</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.function.scss</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.function.scss</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#double-quoted</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#single-quoted</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#variable</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\^|\$|\*|~</string>
+					<key>name</key>
+					<string>keyword.other.regex.sass</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#parameters</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>&amp;</string>
 			<key>name</key>


### PR DESCRIPTION
Since it's possible to define user functions with `@function`, they should also be highlighted.