### PR TITLE
Added BEM with ampersand

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -173,6 +173,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
+			<string>[&amp;](-|_){2}[a-zA-Z0-9]+</string>
+			<key>name</key>
+			<string>entity.other.attribute-name.class.sass</string>
+		</dict>
+
+		<dict>
+			<key>match</key>
 			<string>!(important|default|optional)</string>
 			<key>name</key>
 			<string>keyword.other.important.css.sass</string>


### PR DESCRIPTION
Added support to `&__` and `&--` that is used for BEM methodology.
This is a rough and fast modification with a small regex to highlight correctly the BEM with the ampersand annotation.

Feel free to improve it or suggest further modifications.

Thanks