### PR TITLE
remove include of #parameters

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -284,10 +284,6 @@
 					<key>name</key>
 					<string>keyword.other.regex.sass</string>
 				</dict>
-				<dict>
-					<key>include</key>
-					<string>#parameters</string>
-				</dict>
 			</array>
 		</dict>
 		<dict>


### PR DESCRIPTION
This include is not declared in the repository section, so it cannot be working.
Additionally, this prevents the syntax from passing validation before Sublime Text 3
can convert it to a `.sublime-syntax` file.